### PR TITLE
+rga.de

### DIFF
--- a/domains.json
+++ b/domains.json
@@ -319,6 +319,7 @@
     "red-carpet.de",
     "rems-zeitung.de",
     "restauro.de",
+    "rga.de",
     "rga-online.de",
     "rheiderland.de",
     "rnf.de",


### PR DESCRIPTION
The official list got an update yesterday. Two changes took place:

1.) A second domain name for Remscheider Generalanzeiger (rga.de) has been added.
2.) Solinger Tageblatt (solinger-tageblatt.de) is now officially listed by VG Media.

The latter has already been part of our list. Curiously enough.